### PR TITLE
Fix client start dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "yarn workspaces run clean",
     "format": "yarn workspaces run format",
     "docs": "lerna run --scope @dfares/* docs",
-    "start": "concurrently -n contracts,client,watch -c cyan,magenta,blue \"yarn workspace eth start\" \"yarn workspace client start\" \"yarn watch\" "
+    "start": "concurrently -n contracts,client,watch -c cyan,magenta,blue \"yarn workspace eth start\" \"yarn workspace client start:dev\" \"yarn watch\" "
   },
   "devDependencies": {
     "@dfares/constants": "6.8.6",


### PR DESCRIPTION
I noticed that the client dev was not starting and this is why the `start` from top should refer to the `start:dev` when starting the client. Not sure if this is intentional or if this was a bug introduced.