### PR TITLE
feat: settings for sending 100 percent energy as default from planet (WIP)

### DIFF
--- a/client/src/Backend/GameLogic/GameUIManager.ts
+++ b/client/src/Backend/GameLogic/GameUIManager.ts
@@ -1142,7 +1142,12 @@ class GameUIManager extends EventEmitter {
    * Percent from 0 to 100.
    */
   public getForcesSending(planetId?: LocationId): number {
-    const defaultSending = 50;
+    const config = {
+      contractAddress: this.getContractAddress(),
+      account: this.getAccount(),
+    };
+    const send100Percent = getBooleanSetting(config, Setting.Send100PercentEnergyAsDefault);
+    const defaultSending = send100Percent ? 100 : 50;
     if (!planetId) return defaultSending;
 
     if (this.isAbandoning()) return 100;

--- a/client/src/Frontend/Panes/SettingsPane.tsx
+++ b/client/src/Frontend/Panes/SettingsPane.tsx
@@ -349,6 +349,17 @@ export function SettingsPane({
         </Section>
 
         <Section>
+          <SectionHeader>Send 100 percent energy</SectionHeader>
+          Whether or not the default setting, should be to send 100 percent energy from planets as the default.
+          <Spacer height={16} />
+          <BooleanSetting
+            uiManager={uiManager}
+            setting={Setting.Send100PercentEnergyAsDefault}
+            settingDescription={'send 100 percent energy as default'}
+          />
+        </Section>
+
+        <Section>
           <SectionHeader>Import and Export Map Data</SectionHeader>
           <Red>WARNING:</Red> Maps from others could be altered and are not guaranteed to be
           correct!

--- a/client/src/Frontend/Utils/SettingsHooks.tsx
+++ b/client/src/Frontend/Utils/SettingsHooks.tsx
@@ -37,6 +37,7 @@ function onlyInDevelopment(): string {
 const defaultSettings: Record<Setting, string> = {
   [Setting.OptOutMetrics]: onlyInDevelopment(),
   [Setting.AutoApproveNonPurchaseTransactions]: onlyInDevelopment(),
+  [Setting.Send100PercentEnergyAsDefault]: onlyInDevelopment(),
   [Setting.DrawChunkBorders]: 'false',
   [Setting.HighPerformanceRendering]: 'false',
   [Setting.MoveNotifications]: 'true',

--- a/client/src/Frontend/Views/SendResources.tsx
+++ b/client/src/Frontend/Views/SendResources.tsx
@@ -1,6 +1,6 @@
 import { formatNumber, isSpaceShip } from '@dfares/gamelogic';
 import { isUnconfirmedMoveTx, isUnconfirmedReleaseTx } from '@dfares/serde';
-import { Artifact, artifactNameFromArtifact, Planet, TooltipName } from '@dfares/types';
+import { Artifact, artifactNameFromArtifact, Planet, Setting, TooltipName } from '@dfares/types';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { Wrapper } from '../../Backend/Utils/Wrapper';
@@ -19,6 +19,7 @@ import { useEmitterValue } from '../Utils/EmitterHooks';
 import { useOnUp } from '../Utils/KeyEmitters';
 import { TOGGLE_ABANDON, TOGGLE_SEND } from '../Utils/ShortcutConstants';
 import { SelectArtifactRow } from './ArtifactRow';
+import { getBooleanSetting, getSetting } from '../Utils/SettingsHooks';
 
 const StyledSendResources = styled.div`
   display: flex;

--- a/packages/types/src/setting.ts
+++ b/packages/types/src/setting.ts
@@ -32,6 +32,7 @@ export const Setting = {
   GasFeeLimit: 'GasFeeLimit' as Setting,
   TerminalVisible: 'TerminalVisible' as Setting,
   HasAcceptedPluginRisk: 'HasAcceptedPluginRisk' as Setting,
+  Send100PercentEnergyAsDefault: 'Send100PercentEnergyAsDefault' as Setting,
 
   FoundPirates: 'FoundPirates' as Setting,
   TutorialCompleted: 'TutorialCompleted' as Setting,


### PR DESCRIPTION
See video here 👇 for reference. 
https://github.com/dfarchon/DFARES-v0.1/assets/100868875/d71d8882-bdc8-48f3-9655-26e18cb092c0

This just sets 100 percent as default value to use from start not sure if we want to lock it here to always be 100?
Do we wish to lock to 100 percent instead, is my question that i have now.