### PR TITLE
feat: options for setting default energy send from planets

### DIFF
--- a/client/src/Frontend/Panes/SettingsPane.tsx
+++ b/client/src/Frontend/Panes/SettingsPane.tsx
@@ -179,6 +179,8 @@ export function SettingsPane({
     Viewport.instance.setMouseSensitivty(scrollSpeed / 10000);
   }, [scrollSpeed]);
 
+  const defaultEnergySendValues = [...new Array(101)].map((_, index) => String(index));
+
   return (
     <ModalPane id={ModalName.Settings} title='Settings' visible={visible} onClose={onClose}>
       <SettingsContent>
@@ -345,6 +347,26 @@ export function SettingsPane({
             uiManager={uiManager}
             setting={Setting.AutoApproveNonPurchaseTransactions}
             settingDescription={'auto confirm non-purchase transactions'}
+          />
+        </Section>
+
+        <Section>
+          <SectionHeader>Planet Default Energy Level To Send</SectionHeader>
+          Select the planet default energy level to send from planets, note that if you adjust the value manually for a planet this will be new value used.
+          <Spacer height={16} />
+          <MultiSelectSetting
+            uiManager={uiManager}
+            setting={Setting.PlanetDefaultEnergyLevelToSend}
+            values={defaultEnergySendValues}
+            labels={defaultEnergySendValues}
+          />
+          <Spacer height={16} />
+          Select checkbox below if you want that the default energy send value to be used, after energy has been sent from a planet.
+          <Spacer height={16} />
+          <BooleanSetting
+            uiManager={uiManager}
+            setting={Setting.PlanetDefaultEnergyLevelToSendReset}
+            settingDescription={'reset to default energy level'}
           />
         </Section>
 

--- a/client/src/Frontend/Utils/SettingsHooks.tsx
+++ b/client/src/Frontend/Utils/SettingsHooks.tsx
@@ -37,6 +37,8 @@ function onlyInDevelopment(): string {
 const defaultSettings: Record<Setting, string> = {
   [Setting.OptOutMetrics]: onlyInDevelopment(),
   [Setting.AutoApproveNonPurchaseTransactions]: onlyInDevelopment(),
+  [Setting.PlanetDefaultEnergyLevelToSend]: '50',
+  [Setting.PlanetDefaultEnergyLevelToSendReset]: 'false',
   [Setting.DrawChunkBorders]: 'false',
   [Setting.HighPerformanceRendering]: 'false',
   [Setting.MoveNotifications]: 'true',

--- a/client/src/Frontend/Views/SendResources.tsx
+++ b/client/src/Frontend/Views/SendResources.tsx
@@ -1,6 +1,6 @@
 import { formatNumber, isSpaceShip } from '@dfares/gamelogic';
 import { isUnconfirmedMoveTx, isUnconfirmedReleaseTx } from '@dfares/serde';
-import { Artifact, artifactNameFromArtifact, Planet, TooltipName } from '@dfares/types';
+import { Artifact, artifactNameFromArtifact, Planet, Setting, TooltipName } from '@dfares/types';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { Wrapper } from '../../Backend/Utils/Wrapper';
@@ -19,6 +19,7 @@ import { useEmitterValue } from '../Utils/EmitterHooks';
 import { useOnUp } from '../Utils/KeyEmitters';
 import { TOGGLE_ABANDON, TOGGLE_SEND } from '../Utils/ShortcutConstants';
 import { SelectArtifactRow } from './ArtifactRow';
+import { getBooleanSetting, getSetting } from '../Utils/SettingsHooks';
 
 const StyledSendResources = styled.div`
   display: flex;

--- a/packages/types/src/setting.ts
+++ b/packages/types/src/setting.ts
@@ -32,6 +32,8 @@ export const Setting = {
   GasFeeLimit: 'GasFeeLimit' as Setting,
   TerminalVisible: 'TerminalVisible' as Setting,
   HasAcceptedPluginRisk: 'HasAcceptedPluginRisk' as Setting,
+  DefaultEnergySend: 'DefaultEnergySend' as Setting,
+  DefaultEnergySendReset: 'DefaultEnergySendReset' as Setting,
 
   FoundPirates: 'FoundPirates' as Setting,
   TutorialCompleted: 'TutorialCompleted' as Setting,


### PR DESCRIPTION
## What this PR does:

1. User can select default energy from dropdown values `0..100`, this will be the default energy to send when user opens planet panel. However if the user adjusts the energy send value from the planet this will be the new default for the planet, this is the same behaviour as just that the user can selet their own energy planet.
2. However we also add the checkbox option, if selected it  will reset a planet to use the default energy after the energy has been sent from the planet.

## Select the default energy send value 
Here we change the default energy to send, and the energy to send changes whenever we change the default value.

https://github.com/dfarchon/DFARES-v0.1/assets/100868875/d9d4a622-7743-4e47-a79e-c5814ba3de75



##  Manually overriding the energy value
Here we send the default energy, however afterward we manually override the energy send value for the planet and it remains the same, even when we change the default value.

https://github.com/dfarchon/DFARES-v0.1/assets/100868875/fb9dc314-4fcd-43ed-a31a-145b6e6c0a9f

## Selecting that we always use the default energy value

If the user select the checkbox that they want to always use the default energy set, after energy has been sent from the planet we clear the selected value and ensure they use the default value.

https://github.com/dfarchon/DFARES-v0.1/assets/100868875/25165922-8dbb-4c45-80be-eb70786957f9

