### PR TITLE
Fix landing page html

### DIFF
--- a/client/src/Frontend/Pages/LandingPage.tsx
+++ b/client/src/Frontend/Pages/LandingPage.tsx
@@ -133,34 +133,32 @@ export default function LandingPage() {
               <Spacer height={48} />
 
               <LinkContainer>
-                <Round3Title>
-                  <a
-                    className={'link'}
-                    href={DFArchonLinks.twitter}
-                    target='_blank'
-                    rel='noreferrer'
-                  >
-                    Twitter
-                  </a>
-                  <Spacer width={6} />
-                  <a
-                    className={'link'}
-                    href={DFArchonLinks.discord}
-                    target='_blank'
-                    rel='noreferrer'
-                  >
-                    Discord
-                  </a>
-                  <Spacer width={6} />
-                  <a
-                    className={'link'}
-                    href={DFArchonLinks.github}
-                    target='_blank'
-                    rel='noreferrer'
-                  >
-                    Github
-                  </a>
-                </Round3Title>
+                <a
+                  className={'link'}
+                  href={DFArchonLinks.twitter}
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  Twitter
+                </a>
+                <Spacer width={6} />
+                <a
+                  className={'link'}
+                  href={DFArchonLinks.discord}
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  Discord
+                </a>
+                <Spacer width={6} />
+                <a
+                  className={'link'}
+                  href={DFArchonLinks.github}
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  Github
+                </a>
               </LinkContainer>
             </SubTitle>
 
@@ -379,7 +377,7 @@ export default function LandingPage() {
   );
 }
 
-const Round3Title = styled.a`
+const Round3Title = styled.span`
   font-family: 'Start Press 2P', sans-serif;
 `;
 
@@ -481,6 +479,7 @@ export const LinkContainer = styled.div`
     justify-content: center;
     align-items: center;
     color:  ${'#ffc3cd'};
+    font-family: 'Start Press 2P', sans-serif;
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
Simple pr that fixes invalid html on the landing page:

1. We should not have html anchor elements that are not actual links.
2. It's not allowed to use nested anchor elements.

Rather than used `styled.a` we use `styled.span`, which is also an inline element and achieves the same effect as before.

## Got this warning/error from React 

![Screenshot 2024-04-11 at 21 06 18](https://github.com/dfarchon/DFARES-v0.1/assets/100868875/2451e408-1728-430b-985a-c8f3d36803c1)

 
## Test

On the left the old code, on the right the new code.
![Screenshot 2024-04-11 at 21 03 39](https://github.com/darkforest-eth/darkforest-v0.6/assets/100868875/3e58b94f-fb9d-42c4-b1fc-401f6ff80811)



