### PR TITLE
Do not show hotkeys for spectator

### DIFF
--- a/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -1279,6 +1279,7 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
               <GameWindowLayout
                 terminalVisible={terminalVisible}
                 setTerminalVisible={setTerminalVisible}
+                spectate={spectate}
               />
             </UIManagerProvider>
           </TopLevelDivProvider>

--- a/client/src/Frontend/Views/GameWindowLayout.tsx
+++ b/client/src/Frontend/Views/GameWindowLayout.tsx
@@ -52,9 +52,11 @@ import { TopBar } from './TopBar';
 export function GameWindowLayout({
   terminalVisible,
   setTerminalVisible,
+  spectate,
 }: {
   terminalVisible: boolean;
   setTerminalVisible: (visible: boolean) => void;
+  spectate: boolean;
 }) {
   const uiManager = useUIManager();
   const modalManager = uiManager.getModalManager();
@@ -340,7 +342,7 @@ export function GameWindowLayout({
           <NotificationsPane />
           {paneVisible && <CoordsPane />}
           {paneVisible && <ExplorePane />}
-          {bottomHotkeyVisible && !userHotKeysVisibleSetting && userExperimentalVisibleSetting && (
+          {bottomHotkeyVisible && !userHotKeysVisibleSetting && userExperimentalVisibleSetting && !spectate && (
             <>
               <HotkeysArtShipPane selectedPlanetVisible={selectedPlanetVisible} />
               <HotkeysMainLinePane selectedPlanetVisible={selectedPlanetVisible} />


### PR DESCRIPTION
What the title says, when user enters as an spectator only they should not have hotkeys imo. since they are just viewing the ongoing game, just an thought if you disagree @Stx69 @cherryblue1024 just close this PR.