### PR TITLE
fix: lobby landing page

### DIFF
--- a/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -9,7 +9,6 @@ import { utils, Wallet } from 'ethers';
 import { reverse } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { RouteComponentProps, useHistory } from 'react-router-dom';
-import styled from 'styled-components';
 import { makeContractsAPI } from '../../Backend/GameLogic/ContractsAPI';
 import GameManager, { GameManagerEvent } from '../../Backend/GameLogic/GameManager';
 import GameUIManager from '../../Backend/GameLogic/GameUIManager';
@@ -41,6 +40,7 @@ import UIEmitter, { UIEmitterEvent } from '../Utils/UIEmitter';
 import { GameWindowLayout } from '../Views/GameWindowLayout';
 import { Terminal, TerminalHandle } from '../Views/Terminal';
 import { MiniMap, MiniMapHandle } from './components/MiniMap';
+import { BrowserCompatibleState, BrowserIssues } from './components/BrowserIssues';
 
 const enum TerminalPromptStep {
   NONE,
@@ -65,49 +65,10 @@ const enum TerminalPromptStep {
   SPECTATING,
 }
 
-type BrowserCompatibleState = 'unknown' | 'unsupported' | 'supported';
 type TerminalStateOptions = {
   showHelp: boolean;
   depth?: number;
 };
-
-const BrowserIssue = styled.p`
-  color: red;
-  font-size: 24px;
-  line-height: 1.2em;
-  width: 1000%;
-  padding: 1em 0.5em;
-`;
-
-function BrowserIssues({
-  issues,
-  state,
-}: {
-  issues: Incompatibility[];
-  state: BrowserCompatibleState;
-}): JSX.Element {
-  if (state !== 'unsupported') {
-    return <></>;
-  }
-
-  if (issues.includes(Incompatibility.MobileOrTablet)) {
-    return (
-      <BrowserIssue>ERROR: Mobile or tablet device detected. Please use desktop.</BrowserIssue>
-    );
-  }
-
-  if (issues.includes(Incompatibility.NoIDB)) {
-    return <BrowserIssue>ERROR: IndexedDB not found. Try using a different browser</BrowserIssue>;
-  }
-
-  if (issues.includes(Incompatibility.UnsupportedBrowser)) {
-    return (
-      <BrowserIssue>ERROR: Unsupported browser. Try using Brave, Firefox, or Chrome.</BrowserIssue>
-    );
-  }
-
-  return <BrowserIssue>ERROR: Unknonwn error, please refresh browser.</BrowserIssue>;
-}
 
 export function GameLandingPage({ match, location }: RouteComponentProps<{ contract: string }>) {
   const history = useHistory();

--- a/client/src/Frontend/Pages/components/BrowserIssues.tsx
+++ b/client/src/Frontend/Pages/components/BrowserIssues.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import React from 'react';
+
+import { Incompatibility } from "../../Utils/BrowserChecks";
+
+const BrowserIssue = styled.p`
+  color: red;
+  font-size: 24px;
+  line-height: 1.2em;
+  width: 1000%;
+  padding: 1em 0.5em;
+`;
+
+export type BrowserCompatibleState = 'unknown' | 'unsupported' | 'supported';
+
+export function BrowserIssues({
+  issues,
+  state,
+}: {
+  issues: Incompatibility[];
+  state: BrowserCompatibleState;
+}): JSX.Element {
+  if (state !== 'unsupported') {
+    return <></>;
+  }
+
+  if (issues.includes(Incompatibility.MobileOrTablet)) {
+    return (
+      <BrowserIssue>ERROR: Mobile or tablet device detected. Please use desktop.</BrowserIssue>
+    );
+  }
+
+  if (issues.includes(Incompatibility.NoIDB)) {
+    return <BrowserIssue>ERROR: IndexedDB not found. Try using a different browser</BrowserIssue>;
+  }
+
+  if (issues.includes(Incompatibility.UnsupportedBrowser)) {
+    return (
+      <BrowserIssue>ERROR: Unsupported browser. Try using Brave, Firefox, or Chrome.</BrowserIssue>
+    );
+  }
+
+  return <BrowserIssue>ERROR: Unknonwn error, please refresh browser.</BrowserIssue>;
+}


### PR DESCRIPTION
What the title says, fixes the landing page so:

1. The terminal is visible if all goes well, since we change the logic a bit here with a visible property on the terminal.
2. The error is shown for an unsupported browser.
3. Common browser issues component shared between landing and lobby page.